### PR TITLE
fix(ci): install wrangler before Cloudflare deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install Wrangler
+        run: npm install -g wrangler@4.76.0
+
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
### Motivation
- The Cloudflare Workers deploy job failed because `npx` could not resolve `wrangler@4.76.0` at runtime, causing the deployment step to exit with code 1.

### Description
- Update `.github/workflows/deploy.yml` to add `actions/setup-node@v4` with `node-version: '18'` and a step to install `wrangler@4.76.0` via `npm install -g` before invoking `cloudflare/wrangler-action@v3`.
- Keep the existing deploy step and repository root `workingDirectory` unchanged so deployment behavior is preserved.

### Testing
- Verified the workflow file contains `actions/setup-node@v4`, `npm install -g wrangler@4.76.0`, and `cloudflare/wrangler-action@v3` with a small Python assertion script (passed).
- Reviewed the edited file with `nl -ba .github/workflows/deploy.yml` to confirm exact lines were added (passed).
- Committed the change with `git commit -m "fix: install wrangler before deploy (TASK-unknown)"` and confirmed the working tree is clean (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12f6dba00832a9288aa7962d16f13)