### PR TITLE
fix: add @-mention detection, missing keywords, and remove dead code

### DIFF
--- a/b24-imbot/worker.js
+++ b/b24-imbot/worker.js
@@ -1172,12 +1172,15 @@ export default {
         "цена", "стоимость", "скидка",
         "кп", "коммерческ",
         "заказ", "поставка", "наличие", "срок",
+        "каталог", "аналог",
       ];
 
       if (isGroupChat) {
         const lower = message.toLowerCase();
         const hit = KEYWORDS.find(kw => lower.includes(kw));
-        if (!hit) return json({ ok: true }); // не реагировать — ключевых слов нет
+        // также реагируем если бот @-упомянут (Bitrix24 кодирует как [USER=<id>])
+        const botMentioned = env.BOT_ID && message.includes(`[USER=${env.BOT_ID}]`);
+        if (!hit && !botMentioned) return json({ ok: true }); // не реагировать
       }
 
       // Команды (работают и в личном чате, и в групповом)

--- a/scripts/build_kb_seed.py
+++ b/scripts/build_kb_seed.py
@@ -118,8 +118,6 @@ def classify(rel_path: str) -> tuple[str, int, str] | None:
         return None
     if path.startswith('kb/ru/') and path.endswith(('/README.md', '/INDEX.md')):
         return 'article', 1, 'ru'
-    if path == 'kb/ru/INDEX.md':
-        return 'article', 1, 'ru'
     if path.startswith('prompts/') and path.endswith('.md'):
         return 'prompt', 0, 'ru'
     if path.startswith('_templates/') and path.endswith('.md'):


### PR DESCRIPTION
- Group chat filter in worker.js: add "каталог" and "аналог" to KEYWORDS
  list (these are core bearing/catalog terms that were missing)
- Group chat filter: respond when bot is @-mentioned via [USER=<BOT_ID>]
  BB-code (documented in CLAUDE.md but not implemented)
- build_kb_seed.py classify(): remove unreachable branch for
  'kb/ru/INDEX.md' (already matched by the startswith+endswith guard above)

https://claude.ai/code/session_01KL7tGHCJeXJ5Ei4CnScWax